### PR TITLE
feat: update sablier to v0.2.6

### DIFF
--- a/config/appsList.js
+++ b/config/appsList.js
@@ -112,7 +112,7 @@ const safeAppsConfig = [
   },
   // Sablier
   {
-    url: `${process.env.REACT_APP_IPFS_GATEWAY}/QmbGzpuwowNwnDbTNfzcsTqndKmdkax8gL6ADSeQP2ZSoW`,
+    url: `${process.env.REACT_APP_IPFS_GATEWAY}/QmeFPwySJUPpjSS16imQJWP8b1BArn9UPfapAbpd7qDzQm`,
     networks: [ETHEREUM_NETWORK.MAINNET, ETHEREUM_NETWORK.RINKEBY],
   },
   // Synthetix

--- a/public/gnosis-default.applist.json
+++ b/public/gnosis-default.applist.json
@@ -1,6 +1,6 @@
 {
   "name": "Gnosis Safe default apps list",
-  "timestamp": "2021-05-04T09:59:43.759Z",
+  "timestamp": "2021-05-06T20:18:50Z",
   "version": {
     "major": 0,
     "minor": 1,
@@ -276,10 +276,10 @@
       ]
     },
     {
-      "id": "{\"url\":\"https://cloudflare-ipfs.com/ipfs/QmbGzpuwowNwnDbTNfzcsTqndKmdkax8gL6ADSeQP2ZSoW\",\"name\":\"S\"}",
-      "url": "https://cloudflare-ipfs.com/ipfs/QmbGzpuwowNwnDbTNfzcsTqndKmdkax8gL6ADSeQP2ZSoW",
+      "id": "{\"url\":\"https://cloudflare-ipfs.com/ipfs/QmeFPwySJUPpjSS16imQJWP8b1BArn9UPfapAbpd7qDzQm\",\"name\":\"S\"}",
+      "url": "https://cloudflare-ipfs.com/ipfs/QmeFPwySJUPpjSS16imQJWP8b1BArn9UPfapAbpd7qDzQm",
       "name": "Sablier",
-      "iconUrl": "https://cloudflare-ipfs.com/ipfs/QmbGzpuwowNwnDbTNfzcsTqndKmdkax8gL6ADSeQP2ZSoW/logo.svg",
+      "iconUrl": "https://cloudflare-ipfs.com/ipfs/QmeFPwySJUPpjSS16imQJWP8b1BArn9UPfapAbpd7qDzQm/logo.svg",
       "description": "Safe App for interacting with the Sablier protocol",
       "iconPath": "logo.svg",
       "providedBy": {


### PR DESCRIPTION
Verify on the release page: https://github.com/paulrberg/sablier-safe-app/releases/tag/0.2.6

This update is important because it uses a new Infura key. The old one was one a free account, and that has caused us trouble.