### PR TITLE
Update 1inch v1.3.0

### DIFF
--- a/config/appsList.js
+++ b/config/appsList.js
@@ -15,7 +15,7 @@ const ETHEREUM_NETWORK = {
 const safeAppsConfig = [
   // 1inch
   {
-    url: `${process.env.REACT_APP_IPFS_GATEWAY}/QmUXF1yVGdqUfMbhNyfM3jpP6Bw66cYnKPoWq6iHkhd3Aw`,
+    url: `${process.env.REACT_APP_IPFS_GATEWAY}/QmVeJAAnpDEBwDSTSQvGdWA8JbJqiF5qb5hWVTKPoHPEFJ`,
     networks: [ETHEREUM_NETWORK.MAINNET],
   },
   // Aave

--- a/config/appsList.js
+++ b/config/appsList.js
@@ -15,7 +15,7 @@ const ETHEREUM_NETWORK = {
 const safeAppsConfig = [
   // 1inch
   {
-    url: `${process.env.REACT_APP_IPFS_GATEWAY}/QmVeJAAnpDEBwDSTSQvGdWA8JbJqiF5qb5hWVTKPoHPEFJ`,
+    url: `${process.env.REACT_APP_IPFS_GATEWAY}/Qmb3e9wpqQx2mTGwvjskGQqJsi2j2YkQerGpvv7GLFDuKJ`,
     networks: [ETHEREUM_NETWORK.MAINNET],
   },
   // Aave

--- a/public/gnosis-default.applist.json
+++ b/public/gnosis-default.applist.json
@@ -1,6 +1,6 @@
 {
   "name": "Gnosis Safe default apps list",
-  "timestamp": "2021-05-11T09:06:43.868Z",
+  "timestamp": "2021-05-12T13:18:13.108Z",
   "version": {
     "major": 0,
     "minor": 1,
@@ -16,10 +16,10 @@
   ],
   "apps": [
     {
-      "id": "{\"url\":\"https://cloudflare-ipfs.com/ipfs/QmVeJAAnpDEBwDSTSQvGdWA8JbJqiF5qb5hWVTKPoHPEFJ\",\"name\":\"1\"}",
-      "url": "https://cloudflare-ipfs.com/ipfs/QmVeJAAnpDEBwDSTSQvGdWA8JbJqiF5qb5hWVTKPoHPEFJ",
+      "id": "{\"url\":\"https://cloudflare-ipfs.com/ipfs/Qmb3e9wpqQx2mTGwvjskGQqJsi2j2YkQerGpvv7GLFDuKJ\",\"name\":\"1\"}",
+      "url": "https://cloudflare-ipfs.com/ipfs/Qmb3e9wpqQx2mTGwvjskGQqJsi2j2YkQerGpvv7GLFDuKJ",
       "name": "1inch.exchange",
-      "iconUrl": "https://cloudflare-ipfs.com/ipfs/QmVeJAAnpDEBwDSTSQvGdWA8JbJqiF5qb5hWVTKPoHPEFJ/assets/1inch.png",
+      "iconUrl": "https://cloudflare-ipfs.com/ipfs/Qmb3e9wpqQx2mTGwvjskGQqJsi2j2YkQerGpvv7GLFDuKJ/assets/1inch.png",
       "description": "DEX aggregator with the best prices on the market",
       "iconPath": "assets/1inch.png",
       "providedBy": {

--- a/public/gnosis-default.applist.json
+++ b/public/gnosis-default.applist.json
@@ -1,6 +1,6 @@
 {
   "name": "Gnosis Safe default apps list",
-  "timestamp": "2021-05-06T20:18:50Z",
+  "timestamp": "2021-05-11T09:06:43.868Z",
   "version": {
     "major": 0,
     "minor": 1,
@@ -16,10 +16,10 @@
   ],
   "apps": [
     {
-      "id": "{\"url\":\"https://cloudflare-ipfs.com/ipfs/QmUXF1yVGdqUfMbhNyfM3jpP6Bw66cYnKPoWq6iHkhd3Aw\",\"name\":\"1\"}",
-      "url": "https://cloudflare-ipfs.com/ipfs/QmUXF1yVGdqUfMbhNyfM3jpP6Bw66cYnKPoWq6iHkhd3Aw",
+      "id": "{\"url\":\"https://cloudflare-ipfs.com/ipfs/QmVeJAAnpDEBwDSTSQvGdWA8JbJqiF5qb5hWVTKPoHPEFJ\",\"name\":\"1\"}",
+      "url": "https://cloudflare-ipfs.com/ipfs/QmVeJAAnpDEBwDSTSQvGdWA8JbJqiF5qb5hWVTKPoHPEFJ",
       "name": "1inch.exchange",
-      "iconUrl": "https://cloudflare-ipfs.com/ipfs/QmUXF1yVGdqUfMbhNyfM3jpP6Bw66cYnKPoWq6iHkhd3Aw/assets/1inch.png",
+      "iconUrl": "https://cloudflare-ipfs.com/ipfs/QmVeJAAnpDEBwDSTSQvGdWA8JbJqiF5qb5hWVTKPoHPEFJ/assets/1inch.png",
       "description": "DEX aggregator with the best prices on the market",
       "iconPath": "assets/1inch.png",
       "providedBy": {


### PR DESCRIPTION
Update 1inch app v1.3.0 to use their latest version API v3.0 
Closes #17 

I added this issue to 1inch repository:
https://github.com/1inch/gnosis.1inch.exchange/issues/10

Let's wait until we have the green light here