### PR TITLE
[CSV Airdrop] Extend Networks List

### DIFF
--- a/config/appsList.js
+++ b/config/appsList.js
@@ -52,7 +52,13 @@ const safeAppsConfig = [
   // CSV Airdrop
   {
     url: `${process.env.REACT_APP_IPFS_GATEWAY}/QmdFyTuzHnzj6Z1pRRLqjWXEbH56TBNKo3M1an21zKWCXt`,
-    networks: [ETHEREUM_NETWORK.MAINNET, ETHEREUM_NETWORK.RINKEBY, ETHEREUM_NETWORK.XDAI],
+    networks: [
+      ETHEREUM_NETWORK.MAINNET, 
+      ETHEREUM_NETWORK.RINKEBY, 
+      ETHEREUM_NETWORK.XDAI, 
+      ETHEREUM_NETWORK.BSC, 
+      ETHEREUM_NETWORK.POLYGON,
+    ],
   },
   // Curve
   {


### PR DESCRIPTION
This PR adds BSC and POLYGON networks to CSV Airdrop app. The app itself should not require a change to work. As the app is tested (on other networks) to work without a token list. The only expected difference is that it will Fetch token details (symbol and decimals) from on chain rather than a pre-loaded token list. Hence, token image wouldn't be displayed.

We thought that since main functionality is expected to work and the token list is only a detail that it would be nice to release this first and follow up with the token list update in a more substantial release.

Note: This PR has been left in Draft State until we have tested at least one transaction on each added network.