### PR TITLE
Update Curve URL

### DIFF
--- a/config/appsList.js
+++ b/config/appsList.js
@@ -56,7 +56,7 @@ const safeAppsConfig = [
   },
   // Curve
   {
-    url: `https://curve.fi`,
+    url: `https://curve.finance/`,
     networks: [ETHEREUM_NETWORK.MAINNET, ETHEREUM_NETWORK.POLYGON],
   },
   // DeFi Saver

--- a/public/gnosis-default.applist.json
+++ b/public/gnosis-default.applist.json
@@ -114,10 +114,10 @@
       ]
     },
     {
-      "id": "{\"url\":\"https://curve.fi\",\"name\":\"Curve\"}",
-      "url": "https://curve.fi",
+      "id": "{\"url\":\"https://curve.finance\",\"name\":\"Curve\"}",
+      "url": "https://curve.finance",
       "name": "Curve",
-      "iconUrl": "https://curve.fi/logo-square.svg",
+      "iconUrl": "https://www.curve.finance/logo-square.svg",
       "description": "Decentralized exchange liquidity pool designed for extremely efficient stablecoin trading and low-risk income for liquidity providers",
       "iconPath": "logo-square.svg",
       "networks": [

--- a/public/gnosis-default.applist.json
+++ b/public/gnosis-default.applist.json
@@ -117,7 +117,7 @@
       "id": "{\"url\":\"https://curve.finance\",\"name\":\"Curve\"}",
       "url": "https://curve.finance",
       "name": "Curve",
-      "iconUrl": "https://www.curve.finance/logo-square.svg",
+      "iconUrl": "https://curve.finance/logo-square.svg",
       "description": "Decentralized exchange liquidity pool designed for extremely efficient stablecoin trading and low-risk income for liquidity providers",
       "iconPath": "logo-square.svg",
       "networks": [


### PR DESCRIPTION
Hi team,

Due to a DNS hijacking issue we've had to migrate the Curve frontend to https://www.curve.finance/, would appreciate any help in updating the link for Curve in the App Registry!

For reference, here's our public statement: https://x.com/CurveFinance/status/1922248878968992014

Let us know if you need any further verification or info.

Thanks!